### PR TITLE
Fix Debug builds

### DIFF
--- a/Libraries/GimSharp/GimSharp.csproj
+++ b/Libraries/GimSharp/GimSharp.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Unsafe code was only enabled for Release builds in the GimSharp project.