### PR TITLE
Fix unsafe access to WriterSettingsControl from worker threads

### DIFF
--- a/PuyoTools/GUI/ArchiveCreator.cs
+++ b/PuyoTools/GUI/ArchiveCreator.cs
@@ -123,9 +123,11 @@ namespace PuyoTools.GUI
             ArchiveWriter archive = Archive.Create(destination, settings.ArchiveFormat);
 
             // Set archive settings
-            if (settings.WriterSettingsControl != null)
+            ModuleSettingsControl settingsControl = settings.WriterSettingsControl;
+            if (settingsControl != null)
             {
-                settings.WriterSettingsControl.SetModuleSettings(archive);
+                Action moduleSettingsAction = () => settingsControl.SetModuleSettings(archive);
+                settingsControl.Invoke(moduleSettingsAction);
             }
 
             // Add the file added event handler the archive

--- a/PuyoTools/GUI/TextureEncoder.cs
+++ b/PuyoTools/GUI/TextureEncoder.cs
@@ -101,9 +101,11 @@ namespace PuyoTools.GUI
                         texture.SourcePath = file;
 
                         // Set texture settings
-                        if (settings.WriterSettingsControl != null)
+                        ModuleSettingsControl settingsControl = settings.WriterSettingsControl;
+                        if (settingsControl != null)
                         {
-                            settings.WriterSettingsControl.SetModuleSettings(texture);
+                            Action moduleSettingsAction = () => settingsControl.SetModuleSettings(texture);
+                            settingsControl.Invoke(moduleSettingsAction);
                         }
 
                         texture.Write(source, buffer, (int)source.Length);


### PR DESCRIPTION
Gets archive creation and texture encoding working again without throwing an InvalidOperationException from trying to use a UI control created on a different thread.