### PR TITLE
Fix some file handle leaks and improve SVR detection.

### DIFF
--- a/Libraries/VrSharp/SvrTexture/SvrTexture.cs
+++ b/Libraries/VrSharp/SvrTexture/SvrTexture.cs
@@ -166,16 +166,24 @@ namespace VrSharp.SvrTexture
             if (length >= 0x20 &&
                 PTMethods.Contains(source, offset + 0x00, Encoding.UTF8.GetBytes("GBIX")) &&
                 PTMethods.Contains(source, offset + 0x10, Encoding.UTF8.GetBytes("PVRT")) &&
-                source[offset + 0x19] >= 0x60 && source[offset + 0x19] < 0x70 &&
-                BitConverter.ToUInt32(source, offset + 0x14) == length - 24)
-                return true;
+                source[offset + 0x19] >= 0x60 && source[offset + 0x19] < 0x70)
+            {
+                // Some SVR files have an extra byte at the end for seemingly no reason.
+                UInt32 expected_length = BitConverter.ToUInt32(source, offset + 0x14);
+                if (expected_length == length - 24 || expected_length == length - 24 - 1)
+                    return true;
+            }
 
             // PVRT (and no GBIX chunk)
             else if (length >= 0x10 &&
                 PTMethods.Contains(source, offset + 0x00, Encoding.UTF8.GetBytes("PVRT")) &&
-                source[offset + 0x19] >= 0x60 && source[offset + 0x19] < 0x70 &&
-                BitConverter.ToUInt32(source, offset + 0x04) == length - 8)
-                return true;
+                source[offset + 0x09] >= 0x60 && source[offset + 0x19] < 0x70)
+            {
+                // Some SVR files have an extra byte at the end for seemingly no reason.
+                UInt32 expected_length = BitConverter.ToUInt32(source, offset + 0x04);
+                if (expected_length == length - 8 || expected_length == length - 8 - 1)
+                    return true;
+            }
 
             return false;
         }

--- a/PuyoTools/GUI/TextureViewer.cs
+++ b/PuyoTools/GUI/TextureViewer.cs
@@ -128,6 +128,7 @@ namespace PuyoTools.GUI
                         // The file is compressed! Let's decompress it and then try to determine if it is a texture
                         MemoryStream decompressedData = new MemoryStream();
                         Compression.Decompress(textureStream, decompressedData, compressionFormat);
+                        textureStream.Close();
                         decompressedData.Position = 0;
 
                         // Now with this decompressed data, let's determine if it is a texture
@@ -147,6 +148,7 @@ namespace PuyoTools.GUI
                     else
                     {
                         // Hmm... doesn't appear to be a texture. Just ignore this file then.
+                        textureStream.Close();
                         return;
                     }
                 }
@@ -169,6 +171,11 @@ namespace PuyoTools.GUI
                         {
                             OpenTexture(textureStream, ofd.SafeFileName, paletteData, textureFormat);
                         }
+                    }
+                    else
+                    {
+                        // Can't load the palette, so close the texture.
+                        textureStream.Close();
                     }
                 }
             }


### PR DESCRIPTION
TextureViewer.cs: Close the texture stream if we're not using it. Otherwise, we end up leaking handles.

SvrTexture.cs: Improve SVR detection.
* Fixed offset of image data type for images that don't have GBIX.
* Some SVR images (e.g. Sega Superstars) have an extra NULL byte at the end for seemingly no reason.