### PR TITLE
Fixing crash when decoding GVR textures with internal palettes.

### DIFF
--- a/Libraries/VrSharp/GvrTexture/GvrTexture.cs
+++ b/Libraries/VrSharp/GvrTexture/GvrTexture.cs
@@ -156,7 +156,7 @@ namespace VrSharp.GvrTexture
             dataCodec = GvrDataCodec.GetDataCodec(dataFormat);
 
             // We need a pixel codec if this is a palettized texture
-            if (dataCodec != null && paletteEntries != 0)
+            if (dataCodec != null && dataCodec.PaletteEntries != 0)
             {
                 pixelCodec = GvrPixelCodec.GetPixelCodec(pixelFormat);
 


### PR DESCRIPTION
The paletteEntries field on GvrTexture isn't initialized until after this check, causing the pixel codec to never be initialized, and it crashes with a NullReferenceException.