### PR TITLE
Reimplement .one and .txd

### DIFF
--- a/PuyoTools.Modules/Archive/Formats/OneStorybookArchive.cs
+++ b/PuyoTools.Modules/Archive/Formats/OneStorybookArchive.cs
@@ -1,0 +1,112 @@
+﻿using PuyoTools.Modules.Compression;
+using System;
+using System.IO;
+
+namespace PuyoTools.Modules.Archive
+{
+    public class OneStorybookArchive : ArchiveBase
+    {
+        /// <summary>
+        /// Name of the format.
+        /// </summary>
+        public override string Name
+        {
+            get { return "ONE (Sonic and the Secret Rings)"; }
+        }
+
+        /// <summary>
+        /// The primary file extension for this archive format.
+        /// </summary>
+        public override string FileExtension
+        {
+            get { return ".one"; }
+        }
+
+        /// <summary>
+        /// Returns if data can be written to this format.
+        /// </summary>
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override ArchiveReader Open(Stream source)
+        {
+            return new OneStorybookArchiveReader(source);
+        }
+
+        public override ArchiveWriter Create(Stream destination)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Is(Stream source, int length, string fname)
+        {
+            if (PTStream.ReadUInt32BEAt(source, 0x4) != 0x10)
+                return false;
+
+            var i = PTStream.ReadUInt32BEAt(source, 0xC);
+
+            if (i != 0xFFFFFFFF && i != 0x00000000)
+                return false;
+
+            source.Seek(0, SeekOrigin.Begin);
+            return true;
+        }
+    }
+
+    #region Archive Reader
+    public class OneStorybookArchiveReader : ArchiveReader
+    {
+        private PrsCompression _prsCompression;
+
+        public OneStorybookArchiveReader(Stream source) : base(source)
+        {
+            _prsCompression = new PrsCompression();
+
+            // Get the number of entries in the archive
+            int numEntries = PTStream.ReadInt32BE(source);
+            entries = new ArchiveEntryCollection(this, numEntries);
+
+            // Read in all the entries
+            for (int i = 0; i < numEntries; i++)
+            {
+                source.Position = 0x34 + (i * 0x30);
+                int entryOffset = PTStream.ReadInt32BE(source);
+                int entryLength = PTStream.ReadInt32BE(source);
+                string entryFilename = PTStream.ReadCStringAt(source, 0x10 + (i * 0x30), 0x20);
+
+                // Add this entry to the collection
+                entries.Add(startOffset + entryOffset, entryLength, entryFilename);
+            }
+
+            // Set the position of the stream to the end of the file
+            source.Seek(0, SeekOrigin.End);
+        }
+
+        public override Stream OpenEntry(ArchiveEntry entry)
+        {
+            archiveData.Seek(entry.Offset, SeekOrigin.Begin);
+            var memoryStream = new MemoryStream();
+            _prsCompression.Decompress(archiveData, memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+            return memoryStream;
+        }
+    }
+    #endregion
+
+    public class OneStorybookArchiveWriter : ArchiveWriter
+    {
+        private PrsCompression _prsCompression;
+
+        public OneStorybookArchiveWriter(Stream dest) : base(dest)
+        {
+            _prsCompression = new PrsCompression();
+        }
+
+        public override void Flush()
+        {
+
+        }
+    }
+}

--- a/PuyoTools.Modules/Archive/Formats/TxdStorybookArchive.cs
+++ b/PuyoTools.Modules/Archive/Formats/TxdStorybookArchive.cs
@@ -1,0 +1,130 @@
+﻿using PuyoTools.Modules.Compression;
+using PuyoTools.Modules.Texture;
+using System;
+using System.IO;
+
+namespace PuyoTools.Modules.Archive
+{
+    public class TxdStorybookArchive : ArchiveBase
+    {
+        /// <summary>
+        /// Name of the format.
+        /// </summary>
+        public override string Name
+        {
+            get { return "TXD (Sonic and the Secret Rings)"; }
+        }
+
+        /// <summary>
+        /// The primary file extension for this archive format.
+        /// </summary>
+        public override string FileExtension
+        {
+            get { return ".txd"; }
+        }
+
+        /// <summary>
+        /// Returns if data can be written to this format.
+        /// </summary>
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override ArchiveReader Open(Stream source)
+        {
+            return new TxdStorybookArchiveReader(source);
+        }
+
+        public override ArchiveWriter Create(Stream destination)
+        {
+            return new TxdStorybookArchiveWriter(destination);
+        }
+
+        public override bool Is(Stream source, int length, string fname)
+        {
+            source.Position = 0;
+            return (length > 16 && PTStream.Contains(source, 0, new byte[] { (byte)'T', (byte)'X', (byte)'A', (byte)'G' }));
+        }
+    }
+
+    #region Archive Reader
+    public class TxdStorybookArchiveReader : ArchiveReader
+    {
+        public TxdStorybookArchiveReader(Stream source) : base(source)
+        {
+            var fileCount = PTStream.ReadInt32BEAt(source, 0x4);
+            entries = new ArchiveEntryCollection(this, fileCount);
+
+            for (int i = 0; i < fileCount; i++)
+            {
+                var fileName = PTStream.ReadCStringAt(source, 0x10 + (i * 0x28), 32);
+                var offset = PTStream.ReadUInt32BEAt(source, 0x08 + (i * 0x28));
+                var length = PTStream.ReadInt32BEAt(source, 0x0C + (i * 0x28));
+
+                fileName = string.IsNullOrWhiteSpace(fileName) ? fileName : Path.ChangeExtension(fileName, "GVR");
+
+                entries.Add(startOffset + offset, length, fileName);
+            }
+        }
+
+    }
+    #endregion
+
+    public class TxdStorybookArchiveWriter : ArchiveWriter
+    {
+        public TxdStorybookArchiveWriter(Stream destination) : base(destination) { }
+
+        /// <summary>
+        /// Creates an entry that has the specified data entry name in the archive.
+        /// </summary>
+        /// <param name="source">The data to be added to the archive.</param>
+        /// <param name="entryName">The name of the entry to be created.</param>
+        /// <remarks>
+        /// The file may be rejected from the archive. In this case, a CannotAddFileToArchiveException will be thrown.
+        /// </remarks>
+        public override void CreateEntry(Stream source, string entryName)
+        {
+            // Only PVR textures can be added to a PVM archive. If this is not a PVR texture, throw an exception.
+            if (!(new GvrTexture()).Is(source, entryName))
+            {
+                throw new CannotAddFileToArchiveException();
+            }
+
+            base.CreateEntry(source, entryName.ToUpper());
+        }
+
+        public override void Flush()
+        {
+            const int blockSize = 64;
+            var offsetList = new int[entries.Count];
+
+            destination.WriteByte((byte)'T');
+            destination.WriteByte((byte)'X');
+            destination.WriteByte((byte)'A');
+            destination.WriteByte((byte)'G');
+
+            PTStream.WriteInt32BE(destination, entries.Count);
+
+            var offset = PTMethods.RoundUp(0x8 + (entries.Count * 0x28), blockSize);
+            for (int i = 0; i < entries.Count; i++)
+            {
+                var length = entries[i].Length;
+                offsetList[i] = offset;
+
+                PTStream.WriteInt32BE(destination, offset);
+                PTStream.WriteInt32BE(destination, length);
+                PTStream.WriteCString(destination, Path.GetFileNameWithoutExtension(entries[i].Name), 32);
+
+                offset += PTMethods.RoundUp(length, blockSize);
+            }
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                destination.Position = offsetList[i];
+                PTStream.CopyToPadded(entries[i].Open(), destination, blockSize, 0);
+                OnFileAdded(EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/PuyoTools.Modules/Core/PTStream.cs
+++ b/PuyoTools.Modules/Core/PTStream.cs
@@ -343,6 +343,16 @@ namespace PuyoTools.Modules
             return value;
         }
 
+        public static uint ReadUInt32BEAt(Stream source, long offset)
+        {
+            long oldPosition = source.Position;
+            source.Position = offset;
+            uint value = ReadUInt32BE(source);
+            source.Position = oldPosition;
+
+            return value;
+        }
+
         /// <summary>
         /// Reads an ASCII encoded null terminated C string from a stream.
         /// The stream is read until a null byte is reached.
@@ -394,6 +404,28 @@ namespace PuyoTools.Modules
             }
 
             return encoding.GetString(buffer, 0, index);
+        }
+
+        public static string ReadCStringAt(Stream source, int offset, int? length = null, Encoding encoding = null)
+        {
+            long oldPosition = source.Position;
+            try
+            {
+                source.Position = offset;
+
+                if (length == null)
+                {
+                    return ReadCString(source);
+                }
+                else
+                {
+                    return ReadCString(source, length.Value, encoding ?? Encoding.ASCII);
+                }
+            }
+            finally
+            {
+                source.Position = oldPosition;
+            }
         }
 
         /// <summary>

--- a/PuyoTools.Modules/PuyoTools.Modules.csproj
+++ b/PuyoTools.Modules/PuyoTools.Modules.csproj
@@ -61,11 +61,13 @@
     <Compile Include="Archive\Formats\GvmArchive.cs" />
     <Compile Include="Archive\Formats\MrgArchive.cs" />
     <Compile Include="Archive\Formats\NarcArchive.cs" />
+    <Compile Include="Archive\Formats\OneStorybookArchive.cs" />
     <Compile Include="Archive\Formats\OneUnleashedArchive.cs" />
     <Compile Include="Archive\Formats\PvmArchive.cs" />
     <Compile Include="Archive\Formats\SntArchive.cs" />
     <Compile Include="Archive\Formats\SpkArchive.cs" />
     <Compile Include="Archive\Formats\TexArchive.cs" />
+    <Compile Include="Archive\Formats\TxdStorybookArchive.cs" />
     <Compile Include="Archive\Formats\U8Archive.cs" />
     <Compile Include="Archive\WriterSettings\AcxWriterSettings.cs">
       <SubType>UserControl</SubType>

--- a/PuyoTools/Archive.cs
+++ b/PuyoTools/Archive.cs
@@ -32,6 +32,8 @@ namespace PuyoTools
                 [ArchiveFormat.Spk] = new SpkArchive(),
                 [ArchiveFormat.Tex] = new TexArchive(),
                 [ArchiveFormat.U8] = new U8Archive(),
+                [ArchiveFormat.OneStorybook] = new OneStorybookArchive(),
+                [ArchiveFormat.TxdStorybook] = new TxdStorybookArchive()
             };
         }
 
@@ -82,6 +84,8 @@ namespace PuyoTools
         Spk,
         Tex,
         U8,
+        OneStorybook,
+        TxdStorybook,
         Plugin,
     }
 }

--- a/PuyoTools/GUI/ArchiveExplorer.cs
+++ b/PuyoTools/GUI/ArchiveExplorer.cs
@@ -222,6 +222,10 @@ namespace PuyoTools.GUI
                         return;
                     }
                 }
+
+                // maybe let's actually tell people why their shit won't open
+                // rather than just sitting there like a duck doing nothing?
+                MessageBox.Show("Unknown or unsupported archive format!");
             }
         }
 


### PR DESCRIPTION
It seems that somewhere between 1.1.0 and 2.0.0, the ability to read .one and .txd files from Sonic Storybook games was removed for some reason, this PR reimplements reading and adds the ability to create both .one and .txd files that work at the very least in Sonic and the Secret Rings.

Example:
![tanic](https://cdn.discordapp.com/attachments/464963211410669579/680092453474140240/unknown.png) 